### PR TITLE
Fix deleted layers causing exceptions

### DIFF
--- a/dist/vidar-cjs.js
+++ b/dist/vidar-cjs.js
@@ -9001,11 +9001,12 @@ var Movie = /** @class */ (function () {
     Movie.prototype.pause = function () {
         this._paused = true;
         // Deactivate all layers
-        for (var i = 0; i < this.layers.length; i++) {
-            var layer = this.layers[i];
-            layer.stop();
-            layer.active = false;
-        }
+        for (var i = 0; i < this.layers.length; i++)
+            if (Object.prototype.hasOwnProperty.call(this.layers, i)) {
+                var layer = this.layers[i];
+                layer.stop();
+                layer.active = false;
+            }
         publish(this, 'movie.pause', {});
         return this;
     };
@@ -9054,15 +9055,16 @@ var Movie = /** @class */ (function () {
             if (!this.repeat || this.recording) {
                 this._ended = true;
                 // Deactivate all layers
-                for (var i = 0; i < this.layers.length; i++) {
-                    var layer = this.layers[i];
-                    // A layer that has been deleted before layers.length has been updated
-                    // (see the layers proxy in the constructor).
-                    if (!layer)
-                        continue;
-                    layer.stop();
-                    layer.active = false;
-                }
+                for (var i = 0; i < this.layers.length; i++)
+                    if (Object.prototype.hasOwnProperty.call(this.layers, i)) {
+                        var layer = this.layers[i];
+                        // A layer that has been deleted before layers.length has been updated
+                        // (see the layers proxy in the constructor).
+                        if (!layer)
+                            continue;
+                        layer.stop();
+                        layer.active = false;
+                    }
             }
         }
         // Stop playback or recording if done
@@ -9119,6 +9121,8 @@ var Movie = /** @class */ (function () {
     Movie.prototype._renderLayers = function () {
         var frameFullyLoaded = true;
         for (var i = 0; i < this.layers.length; i++) {
+            if (!Object.prototype.hasOwnProperty.call(this.layers, i))
+                continue;
             var layer = this.layers[i];
             // A layer that has been deleted before layers.length has been updated
             // (see the layers proxy in the constructor).
@@ -9185,7 +9189,8 @@ var Movie = /** @class */ (function () {
      */
     Movie.prototype._publishToLayers = function (type, event) {
         for (var i = 0; i < this.layers.length; i++)
-            publish(this.layers[i], type, event);
+            if (Object.prototype.hasOwnProperty.call(this.layers, i))
+                publish(this.layers[i], type, event);
     };
     Object.defineProperty(Movie.prototype, "rendering", {
         /**

--- a/dist/vidar-iife.js
+++ b/dist/vidar-iife.js
@@ -9002,11 +9002,12 @@ var vd = (function () {
         Movie.prototype.pause = function () {
             this._paused = true;
             // Deactivate all layers
-            for (var i = 0; i < this.layers.length; i++) {
-                var layer = this.layers[i];
-                layer.stop();
-                layer.active = false;
-            }
+            for (var i = 0; i < this.layers.length; i++)
+                if (Object.prototype.hasOwnProperty.call(this.layers, i)) {
+                    var layer = this.layers[i];
+                    layer.stop();
+                    layer.active = false;
+                }
             publish(this, 'movie.pause', {});
             return this;
         };
@@ -9055,15 +9056,16 @@ var vd = (function () {
                 if (!this.repeat || this.recording) {
                     this._ended = true;
                     // Deactivate all layers
-                    for (var i = 0; i < this.layers.length; i++) {
-                        var layer = this.layers[i];
-                        // A layer that has been deleted before layers.length has been updated
-                        // (see the layers proxy in the constructor).
-                        if (!layer)
-                            continue;
-                        layer.stop();
-                        layer.active = false;
-                    }
+                    for (var i = 0; i < this.layers.length; i++)
+                        if (Object.prototype.hasOwnProperty.call(this.layers, i)) {
+                            var layer = this.layers[i];
+                            // A layer that has been deleted before layers.length has been updated
+                            // (see the layers proxy in the constructor).
+                            if (!layer)
+                                continue;
+                            layer.stop();
+                            layer.active = false;
+                        }
                 }
             }
             // Stop playback or recording if done
@@ -9120,6 +9122,8 @@ var vd = (function () {
         Movie.prototype._renderLayers = function () {
             var frameFullyLoaded = true;
             for (var i = 0; i < this.layers.length; i++) {
+                if (!Object.prototype.hasOwnProperty.call(this.layers, i))
+                    continue;
                 var layer = this.layers[i];
                 // A layer that has been deleted before layers.length has been updated
                 // (see the layers proxy in the constructor).
@@ -9186,7 +9190,8 @@ var vd = (function () {
          */
         Movie.prototype._publishToLayers = function (type, event) {
             for (var i = 0; i < this.layers.length; i++)
-                publish(this.layers[i], type, event);
+                if (Object.prototype.hasOwnProperty.call(this.layers, i))
+                    publish(this.layers[i], type, event);
         };
         Object.defineProperty(Movie.prototype, "rendering", {
             /**

--- a/spec/movie.spec.js
+++ b/spec/movie.spec.js
@@ -137,6 +137,25 @@ describe('Movie', function () {
       // Expect both layers to only have been `attach`ed once
       expect(added.attach.calls.count()).toBe(1)
     })
+
+    it('should be able to operate after a layer has been deleted', function (done) {
+      // Start with three layers
+      movie.addLayer(createBaseLayer())
+      movie.addLayer(createBaseLayer())
+      movie.addLayer(createBaseLayer())
+
+      // Delete the middle layer
+      delete movie.layers[1]
+
+      // Wait to end the test until the movie's done pausing.
+      vd.event.subscribe(movie, 'movie.pause', done)
+
+      // Let the movie play and pause it again
+      movie.play()
+      expect(movie.paused).toBe(false)
+      movie.pause()
+      expect(movie.paused).toBe(true)
+    })
   })
 
   describe('effects ->', function () {

--- a/src/movie.ts
+++ b/src/movie.ts
@@ -325,9 +325,11 @@ export class Movie {
     this._paused = true
     // Deactivate all layers
     for (let i = 0; i < this.layers.length; i++) {
-      const layer = this.layers[i]
-      layer.stop()
-      layer.active = false
+      if (this.layers.hasOwnProperty(i)) {
+        const layer = this.layers[i]
+        layer.stop()
+        layer.active = false
+      }
     }
     publish(this, 'movie.pause', {})
     return this
@@ -381,14 +383,16 @@ export class Movie {
         this._ended = true
         // Deactivate all layers
         for (let i = 0; i < this.layers.length; i++) {
-          const layer = this.layers[i]
-          // A layer that has been deleted before layers.length has been updated
-          // (see the layers proxy in the constructor).
-          if (!layer)
-            continue
+          if (this.layers.hasOwnProperty(i)) {
+            const layer = this.layers[i]
+            // A layer that has been deleted before layers.length has been updated
+            // (see the layers proxy in the constructor).
+            if (!layer)
+              continue
 
-          layer.stop()
-          layer.active = false
+            layer.stop()
+            layer.active = false
+          }
         }
       }
     }
@@ -456,6 +460,8 @@ export class Movie {
   private _renderLayers () {
     let frameFullyLoaded = true
     for (let i = 0; i < this.layers.length; i++) {
+      if (!this.layers.hasOwnProperty(i)) continue;
+
       const layer = this.layers[i]
       // A layer that has been deleted before layers.length has been updated
       // (see the layers proxy in the constructor).
@@ -531,8 +537,11 @@ export class Movie {
    * Convienence method
    */
   private _publishToLayers (type, event) {
-    for (let i = 0; i < this.layers.length; i++)
-      publish(this.layers[i], type, event)
+    for (let i = 0; i < this.layers.length; i++) {
+      if (this.layers.hasOwnProperty(i)) {
+        publish(this.layers[i], type, event)
+      }
+    }
   }
 
   /**

--- a/src/movie.ts
+++ b/src/movie.ts
@@ -324,13 +324,13 @@ export class Movie {
   pause (): Movie {
     this._paused = true
     // Deactivate all layers
-    for (let i = 0; i < this.layers.length; i++) {
-      if (this.layers.hasOwnProperty(i)) {
+    for (let i = 0; i < this.layers.length; i++)
+      if (Object.prototype.hasOwnProperty.call(this.layers, i)) {
         const layer = this.layers[i]
         layer.stop()
         layer.active = false
       }
-    }
+
     publish(this, 'movie.pause', {})
     return this
   }
@@ -382,8 +382,8 @@ export class Movie {
       if (!this.repeat || this.recording) {
         this._ended = true
         // Deactivate all layers
-        for (let i = 0; i < this.layers.length; i++) {
-          if (this.layers.hasOwnProperty(i)) {
+        for (let i = 0; i < this.layers.length; i++)
+          if (Object.prototype.hasOwnProperty.call(this.layers, i)) {
             const layer = this.layers[i]
             // A layer that has been deleted before layers.length has been updated
             // (see the layers proxy in the constructor).
@@ -393,7 +393,6 @@ export class Movie {
             layer.stop()
             layer.active = false
           }
-        }
       }
     }
 
@@ -460,7 +459,7 @@ export class Movie {
   private _renderLayers () {
     let frameFullyLoaded = true
     for (let i = 0; i < this.layers.length; i++) {
-      if (!this.layers.hasOwnProperty(i)) continue;
+      if (!Object.prototype.hasOwnProperty.call(this.layers, i)) continue
 
       const layer = this.layers[i]
       // A layer that has been deleted before layers.length has been updated
@@ -537,11 +536,9 @@ export class Movie {
    * Convienence method
    */
   private _publishToLayers (type, event) {
-    for (let i = 0; i < this.layers.length; i++) {
-      if (this.layers.hasOwnProperty(i)) {
+    for (let i = 0; i < this.layers.length; i++)
+      if (Object.prototype.hasOwnProperty.call(this.layers, i))
         publish(this.layers[i], type, event)
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
In a current project I need to delete layers that might have already been added to vidar, which will cause this exception when trying to pause vidar:
```
TypeError: Cannot read property 'stop' of undefined
            at Proxy.Movie.pause (dist/vidar-iife.js:9008:23)
            at UserContext.<anonymous> (spec/movie.spec.js:156:13)
```

Currently, vidar will not use `layers.hasOwnProperty(...)` when looping through layers. vidar defines a Proxy method for `delete`-ing layers though (https://github.com/clabe45/vidar/blob/4dadcbc4552c9fe4a6394c61b6f9481a167ad642/src/movie.ts#L128) which implies that deleting layers should be possible but doing so will cause the layers array to contain empty properties, throwing these exceptions.

This PR adds checks using `Object.prototype.hasOwnProperty.call(this.layers, i)` (eslint's recommended way of doing this) to the layers loops which will fix these exceptions being thrown and instead simply skip over empty properties.

This PR also adds a new testcase which tests that vidar can still play and pause even after layers have been paused.

Testcase before fix:
```
Chrome Headless Movie layers -> should be able to operate after a layer has been deleted FAILED
        TypeError: Cannot read property 'stop' of undefined
            at <Jasmine>
            at Proxy.Movie.pause (dist/vidar-iife.js:9008:23)
            at UserContext.<anonymous> (spec/movie.spec.js:156:13)
            at <Jasmine>
```

Testcase with fix does not fail.


Also sidenote, trying to run the tests caused an error "Cannot find plugin "./node_modules/karma-requirejs". Did you forget to install it?" on my machine where I needed to manually install requirejs via `npm install requirejs --save-dev` as it doesn't seem to be included in this project's package.json directly. Have I overread something there?