### PR TITLE
:wrench: add mime type option in media recorder

### DIFF
--- a/dist/vidar-cjs.js
+++ b/dist/vidar-cjs.js
@@ -2722,79 +2722,57 @@ const createAddAudioWorkletModule = (cacheTestResult, createNotSupportedError, e
                  * }
                  * ```
                  */
-                const patchedAudioWorkletProcessor = isSupportingPostMessage
-                    ? 'AudioWorkletProcessor'
-                    : 'class extends AudioWorkletProcessor {__b=new WeakSet();constructor(){super();(p=>p.postMessage=(q=>(m,t)=>q.call(p,m,t?t.filter(u=>!this.__b.has(u)):t))(p.postMessage))(this.port)}}';
+                const patchedSourceWithoutImportStatements = isSupportingPostMessage
+                    ? sourceWithoutImportStatements
+                    : sourceWithoutImportStatements.replace(/\s+extends\s+AudioWorkletProcessor\s*{/, ` extends (class extends AudioWorkletProcessor {__b=new WeakSet();constructor(){super();(p=>p.postMessage=(q=>(m,t)=>q.call(p,m,t?t.filter(u=>!this.__b.has(u)):t))(p.postMessage))(this.port)}}){`);
                 /*
                  * Bug #170: Chrome and Edge do call process() with an array with empty channelData for each input if no input is connected.
                  *
                  * Bug #179: Firefox does not allow to transfer any buffer which has been passed to the process() method as an argument.
                  *
-                 * Bug #190: Safari doesn't throw an error when loading an unparsable module.
-                 *
                  * This is the unminified version of the code used below:
                  *
                  * ```js
                  * `${ importStatements };
-                 * ((AudioWorkletProcessor, registerProcessor) => {${ sourceWithoutImportStatements }
-                 * })(
-                 *     ${ patchedAudioWorkletProcessor },
-                 *     (name, processorCtor) => registerProcessor(name, class extends processorCtor {
+                 * ((registerProcessor) => {${ sourceWithoutImportStatements }
+                 * })((name, processorCtor) => registerProcessor(name, class extends processorCtor {
                  *
-                 *         __collectBuffers = (array) => {
-                 *             array.forEach((element) => this.__buffers.add(element.buffer));
-                 *         };
+                 *     __collectBuffers = (array) => {
+                 *         array.forEach((element) => this.__buffers.add(element.buffer));
+                 *     };
                  *
-                 *         process (inputs, outputs, parameters) {
-                 *             inputs.forEach(this.__collectBuffers);
-                 *             outputs.forEach(this.__collectBuffers);
-                 *             this.__collectBuffers(Object.values(parameters));
+                 *     process (inputs, outputs, parameters) {
+                 *         inputs.forEach(this.__collectBuffers);
+                 *         outputs.forEach(this.__collectBuffers);
+                 *         this.__collectBuffers(Object.values(parameters));
                  *
-                 *             return super.process(
-                 *                 (inputs.map((input) => input.some((channelData) => channelData.length === 0)) ? [ ] : input),
-                 *                 outputs,
-                 *                 parameters
-                 *             );
-                 *         }
-                 *
-                 *     })
-                 * );
-                 *
-                 * registerProcessor('__sac', class extends AudioWorkletProcessor{
-                 *
-                 *     process () {
-                 *         return false;
+                 *         return super.process(
+                 *             (inputs.map((input) => input.some((channelData) => channelData.length === 0)) ? [ ] : input),
+                 *             outputs,
+                 *             parameters
+                 *         );
                  *     }
                  *
-                 * })`
+                 * }))`
                  * ```
                  */
                 const memberDefinition = isSupportingPostMessage ? '' : '__c = (a) => a.forEach(e=>this.__b.add(e.buffer));';
                 const bufferRegistration = isSupportingPostMessage
                     ? ''
                     : 'i.forEach(this.__c);o.forEach(this.__c);this.__c(Object.values(p));';
-                const wrappedSource = `${importStatements};((AudioWorkletProcessor,registerProcessor)=>{${sourceWithoutImportStatements}
-})(${patchedAudioWorkletProcessor},(n,p)=>registerProcessor(n,class extends p{${memberDefinition}process(i,o,p){${bufferRegistration}return super.process(i.map(j=>j.some(k=>k.length===0)?[]:j),o,p)}}));registerProcessor('__sac',class extends AudioWorkletProcessor{process(){return !1}})`;
+                const wrappedSource = `${importStatements};(registerProcessor=>{${patchedSourceWithoutImportStatements}
+})((n,p)=>registerProcessor(n,class extends p{${memberDefinition}process(i,o,p){${bufferRegistration}return super.process(i.map(j=>j.some(k=>k.length===0)?[]:j),o,p)}}))`;
                 const blob = new Blob([wrappedSource], { type: 'application/javascript; charset=utf-8' });
                 const url = URL.createObjectURL(blob);
                 return nativeContext.audioWorklet
                     .addModule(url, options)
                     .then(() => {
                     if (isNativeOfflineAudioContext(nativeContext)) {
-                        return nativeContext;
+                        return;
                     }
                     // Bug #186: Chrome, Edge and Opera do not allow to create an AudioWorkletNode on a closed AudioContext.
                     const backupOfflineAudioContext = getOrCreateBackupOfflineAudioContext(nativeContext);
-                    return backupOfflineAudioContext.audioWorklet.addModule(url, options).then(() => backupOfflineAudioContext);
-                })
-                    .then((nativeContextOrBackupOfflineAudioContext) => {
-                    try {
-                        // Bug #190: Safari doesn't throw an error when loading an unparsable module.
-                        new AudioWorkletNode(nativeContextOrBackupOfflineAudioContext, '__sac'); // tslint:disable-line:no-unused-expression
-                    }
-                    catch {
-                        throw new SyntaxError();
-                    }
+                    return backupOfflineAudioContext.audioWorklet.addModule(url, options);
                 })
                     .finally(() => URL.revokeObjectURL(url));
             });
@@ -3475,17 +3453,7 @@ const createAudioContextConstructor = (baseAudioContextConstructor, createInvali
             if (nativeAudioContextConstructor === null) {
                 throw new Error('Missing the native AudioContext constructor.');
             }
-            let nativeAudioContext;
-            try {
-                nativeAudioContext = new nativeAudioContextConstructor(options);
-            }
-            catch (err) {
-                // Bug #192 Safari does throw a SyntaxError if the sampleRate is not supported.
-                if (err.code === 12 && err.message === 'sampleRate is not in range') {
-                    throw createNotSupportedError();
-                }
-                throw err;
-            }
+            const nativeAudioContext = new nativeAudioContextConstructor(options);
             // Bug #131 Safari returns null when there are four other AudioContexts running already.
             if (nativeAudioContext === null) {
                 throw createUnknownError();
@@ -4534,12 +4502,14 @@ const createBaseAudioContextConstructor = (addAudioWorkletModule, analyserNodeCo
             return new waveShaperNodeConstructor(this);
         }
         decodeAudioData(audioData, successCallback, errorCallback) {
-            return decodeAudioData(this._nativeContext, audioData).then((audioBuffer) => {
+            return decodeAudioData(this._nativeContext, audioData)
+                .then((audioBuffer) => {
                 if (typeof successCallback === 'function') {
                     successCallback(audioBuffer);
                 }
                 return audioBuffer;
-            }, (err) => {
+            })
+                .catch((err) => {
                 if (typeof errorCallback === 'function') {
                     errorCallback(err);
                 }
@@ -5074,10 +5044,6 @@ const createDecodeAudioData = (audioBufferStore, cacheTestResult, createDataClon
         // Bug #21: Safari does not support promises yet.
         if (cacheTestResult(testPromiseSupport, () => testPromiseSupport(nativeContext))) {
             return nativeContext.decodeAudioData(audioData).then((audioBuffer) => {
-                // Bug #133: Safari does neuter the ArrayBuffer.
-                detachArrayBuffer(audioData).catch(() => {
-                    // Ignore errors.
-                });
                 // Bug #157: Firefox does not allow the bufferOffset to be out-of-bounds.
                 if (!cacheTestResult(testAudioBufferCopyChannelMethodsOutOfBoundsSupport, () => testAudioBufferCopyChannelMethodsOutOfBoundsSupport(audioBuffer))) {
                     wrapAudioBufferCopyChannelMethodsOutOfBounds(audioBuffer);
@@ -5615,8 +5581,7 @@ const createGetOrCreateBackupOfflineAudioContext = (backupOfflineAudioContextSto
         if (nativeOfflineAudioContextConstructor === null) {
             throw new Error('Missing the native OfflineAudioContext constructor.');
         }
-        // Bug #141: Safari does not support creating an OfflineAudioContext with less than 44100 Hz.
-        backupOfflineAudioContext = new nativeOfflineAudioContextConstructor(1, 1, 44100);
+        backupOfflineAudioContext = new nativeOfflineAudioContextConstructor(1, 1, 8000);
         backupOfflineAudioContextStore.set(nativeContext, backupOfflineAudioContext);
         return backupOfflineAudioContext;
     };
@@ -8228,8 +8193,7 @@ const createTestAudioWorkletProcessorPostMessageSupport = (nativeAudioWorkletNod
         const blob = new Blob(['class A extends AudioWorkletProcessor{process(i){this.port.postMessage(i,[i[0][0].buffer])}}registerProcessor("a",A)'], {
             type: 'application/javascript; charset=utf-8'
         });
-        // Bug #141: Safari does not support creating an OfflineAudioContext with less than 44100 Hz.
-        const offlineAudioContext = new nativeOfflineAudioContextConstructor(1, 128, 44100);
+        const offlineAudioContext = new nativeOfflineAudioContextConstructor(1, 128, 8000);
         const url = URL.createObjectURL(blob);
         let isEmittingMessageEvents = false;
         let isEmittingProcessorErrorEvents = false;
@@ -8240,7 +8204,6 @@ const createTestAudioWorkletProcessorPostMessageSupport = (nativeAudioWorkletNod
             audioWorkletNode.port.onmessage = () => (isEmittingMessageEvents = true);
             audioWorkletNode.onprocessorerror = () => (isEmittingProcessorErrorEvents = true);
             oscillator.connect(audioWorkletNode);
-            oscillator.start(0);
             await offlineAudioContext.startRendering();
         }
         catch {
@@ -8946,6 +8909,9 @@ var Movie = /** @class */ (function () {
             throw new Error('Both video and audio cannot be disabled');
         if (!this.paused)
             throw new Error('Cannot record movie while already playing or recording');
+        var mimeType = options.type || 'video/webm';
+        if (MediaRecorder && MediaRecorder.isTypeSupported && !MediaRecorder.isTypeSupported(mimeType))
+            throw new Error('Please pass a valid MIME type for the exported video');
         return new Promise(function (resolve, reject) {
             var canvasCache = _this.canvas;
             // Record on a temporary canvas context
@@ -8973,7 +8939,8 @@ var Movie = /** @class */ (function () {
                 publish(_this, 'movie.audiodestinationupdate', { movie: _this, destination: audioDestination });
             }
             var stream = new MediaStream(tracks);
-            var mediaRecorder = new MediaRecorder(stream, options.mediaRecorderOptions);
+            var mediaRecorderOptions = __assign(__assign({}, (options.mediaRecorderOptions || {})), { mimeType: mimeType });
+            var mediaRecorder = new MediaRecorder(stream, mediaRecorderOptions);
             mediaRecorder.ondataavailable = function (event) {
                 // if (this._paused) reject(new Error("Recording was interrupted"));
                 if (event.data.size > 0)
@@ -8988,7 +8955,7 @@ var Movie = /** @class */ (function () {
                 _this._mediaRecorder = null;
                 // Construct the exported video out of all the frame blobs.
                 resolve(new Blob(recordedChunks, {
-                    type: options.type || 'video/webm'
+                    type: mimeType
                 }));
             };
             mediaRecorder.onerror = reject;

--- a/spec/movie.spec.js
+++ b/spec/movie.spec.js
@@ -291,9 +291,9 @@ describe('Movie', function () {
     })
 
     it('can record with custom MIME type', function (done) {
-      movie.record({ frameRate: 60, type: 'video/mp4' })
+      movie.record({ frameRate: 60, type: 'video/webm;codecs=vp9' })
         .then(video => {
-          expect(video.type).toBe('video/mp4')
+          expect(video.type).toBe('video/webm;codecs=vp9')
           done()
         })
     })


### PR DESCRIPTION
fixes #95: Updated the movie record function
- create new mime type variable with default value
- pass the mime type in the MediaRecorder
- Update a test case, change video/mp4 as it is not supported in the chrome